### PR TITLE
Add option to use the `arp-scan` command with sudo

### DIFF
--- a/lib/arpscanner.js
+++ b/lib/arpscanner.js
@@ -10,11 +10,13 @@
 
 var extend = require('gextend');
 var spawn = require('child_process').spawn;
+var sudo = require('sudo');
 
 var DEFAULTS = {
     command: 'arp-scan',
     args:['-l'],
-    parser: parse
+    parser: parse,
+    sudo: false
 };
 
 
@@ -37,14 +39,20 @@ function scanner(cb, options){
 
     var out = [],
         buffer = '',
-        errbuf = '';
+        errbuf = '',
+        arp = {};
 
     var parser = options.parser(out);
 
-    var arp = spawn(options.command, options.args);
+    if (options.sudo) {
+        arp = sudo([ options.command, options.args ]);
+    } else {
+        arp = spawn(options.command, options.args);
+    }
+
     arp.stdout.on('data', function onData(data) { buffer += data; });
     arp.stderr.on('data', function onError(data){ errbuf += data; });
-
+    
     arp.on('close', function onClose(code){
         if(code != 0) return cb(code, null);
 

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   "dependencies": {
     "grunt-cli": "^0.1.13",
     "gextend": "^0.1.6",
-    "commander": "^2.7.1"
+    "commander": "^2.7.1",
+    "sudo": "^1.0.3"
   }
 }


### PR DESCRIPTION
This allows the module to be run without root privileges. Only the child process (i.e. the `arp-scan` command) will need it.

For instance, you could add in `/etc/sudoers.d/my-sudoers`:

    foo  ALL = (root) NOPASSWD: /usr/bin/arp-scan

Then, you could run a node.js application with the user `foo`, but run arp-scan with root privilieges when needed.