### PR TITLE
Added promise support

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,23 @@ function onResult(err, data){
 }
 ```
 
+To use the module programmatically with promises:
+```javascript
+var arpscanner = require('arpscan/promise');
+arpscanner()
+    .then(onResult);
+    .catch(onError);
+
+function onResult(data) {
+    console.log(data);
+}
+
+function onError(err) {
+    throw err;
+}
+```
+
+
 The output should be something similar to:
 
 ```javascript
@@ -98,7 +115,7 @@ Licensed under the MIT license.
 
 
 MAC os output:
-
+```
 Interface: en0, datalink type: EN10MB (Ethernet)
 Starting arp-scan 1.9 with 256 hosts (http://www.nta-monitor.com/tools/arp-scan/)
 192.168.1.1 48:f8:b3:1b:57:84   Cisco-Linksys, LLC
@@ -111,9 +128,10 @@ Starting arp-scan 1.9 with 256 hosts (http://www.nta-monitor.com/tools/arp-scan/
 
 890 packets received by filter, 0 packets dropped by kernel
 Ending arp-scan 1.9: 256 hosts scanned in 1.861 seconds (137.56 hosts/sec). 7 responded
+```
 
-
-Raspberry Pi B
+Raspberry Pi B output:
+```
 Interface: eth0, datalink type: EN10MB (Ethernet)
 Starting arp-scan 1.8.1 with 256 hosts (http://www.nta-monitor.com/tools/arp-scan/)
 192.168.1.125   f0:08:f1:5e:65:10   (Unknown)
@@ -129,3 +147,4 @@ Starting arp-scan 1.8.1 with 256 hosts (http://www.nta-monitor.com/tools/arp-sca
 
 11 packets received by filter, 0 packets dropped by kernel
 Ending arp-scan 1.8.1: 256 hosts scanned in 4.393 seconds (58.27 hosts/sec). 10 responded
+```

--- a/lib/arpscanner-promise.js
+++ b/lib/arpscanner-promise.js
@@ -1,0 +1,7 @@
+scanner = require("./arpscanner");
+
+module.exports = function (options) {
+    return new Promise((resolve, reject) => {
+        scanner((err, out) => err ? reject(err) : resolve(out), options);
+    });
+};

--- a/promise.js
+++ b/promise.js
@@ -1,0 +1,1 @@
+module.exports = require("./lib/arpscanner-promise");

--- a/test/arpscanner_test.js
+++ b/test/arpscanner_test.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var arpscanner = require('../lib/arpscanner.js');
+var arpscanner_promise = require("../lib/arpscanner-promise.js");
 
 /*
   ======== A Handy Little Nodeunit Reference ========
@@ -33,4 +34,16 @@ exports['awesome'] = {
     test.equal(arpscanner.awesome(), 'awesome', 'should be awesome.');
     test.done();
   },
+  "promise": function (test) {
+    test.expect(1);
+    arpscanner_promise()
+        .then(out => {
+            test.ok(Array.isArray(out), "output should be array");
+            test.done();
+        })
+        .catch(err => {
+            test.ok(false, err);
+            test.done();
+        });
+  }
 };


### PR DESCRIPTION
I thought I might as well add promise support to your repo.

I have done it as a subfile so it can be used completely indepentandly of non-promise method, for older/legacy versions of Node.

I could have gotten away with just using a single file for this. And that was my original plan, but I left the **"meat"** (if you can call it that) of the code in the lib folder and just used the subfile as a passthrough redirect style. If you would prefer it in a single file, then I can do that instead.

I also added a few code borders to the output part of the Readme and added a `how to` for the promise.

I attempted to add a test script, but found out you had not supplied your GruntFile and it was actually in the ignore folder. So I left it as a starting point. I've never used nodeunit so I hope I've done it right.
