### PR TITLE
arpscan: replace sudo with suspawn

### DIFF
--- a/lib/arpscanner.js
+++ b/lib/arpscanner.js
@@ -10,7 +10,7 @@
 
 var extend = require('gextend');
 var spawn = require('child_process').spawn;
-var sudo = require('sudo');
+var suspawn = require('suspawn');
 
 var DEFAULTS = {
     command: 'arp-scan',
@@ -50,7 +50,7 @@ function scanner(cb, options){
 
     if(options.verbose ) console.log(options.sudo ? 'sudo ' : '' + cmd);
     if (options.sudo) {
-        arp = sudo([ options.command, options.args ]);
+        arp = suspawn(options.command, options.args);
     } else {
         arp = spawn(options.command, options.args);
     }

--- a/package.json
+++ b/package.json
@@ -47,6 +47,6 @@
   "dependencies": {
     "gextend": "^0.1.6",
     "commander": "^2.7.1",
-    "sudo": "^1.0.3"
+    "suspawn": "^0.2.2"
   }
 }


### PR DESCRIPTION
The [`sudo`](https://github.com/calmh/node-sudo) package does no longer seem to be maintained, and I can't get it to work locally (I just get an `error` event from thew spawned child with the `sudo package`). I suggest switching to the [`suspawn`](https://github.com/bmeck/node-suspawn) package, which is even simpler and works for me.