### PR TITLE
Fixes print issue when sudo is enabled

### DIFF
--- a/lib/arpscanner.js
+++ b/lib/arpscanner.js
@@ -49,7 +49,7 @@ function scanner(cb, options){
     var cmd = options.command + ' ' + options.args.join(' ');
 
     if (options.verbose) {
-        console.log(options.sudo ? 'sudo ' : '' + cmd);
+        console.log(`${options.sudo ? 'sudo ' : ''}${cmd}`);
     }
     if (options.sudo) {
         arp = suspawn(options.command, options.args);

--- a/lib/arpscanner.js
+++ b/lib/arpscanner.js
@@ -48,7 +48,9 @@ function scanner(cb, options){
 
     var cmd = options.command + ' ' + options.args.join(' ');
 
-    if(options.verbose ) console.log(options.sudo ? 'sudo ' : '' + cmd);
+    if (options.verbose) {
+        console.log(options.sudo ? 'sudo ' : '' + cmd);
+    }
     if (options.sudo) {
         arp = suspawn(options.command, options.args);
     } else {


### PR DESCRIPTION
This wraps the ternary in the `console.log(...)` in a template literal.

The previous implementation was incorrect because it would return `"sudo "` if `options.sudo` was enabled instead of `"sudo " + msg`.