### PR TITLE
Fix 12

### DIFF
--- a/bin/arpscan
+++ b/bin/arpscan
@@ -32,7 +32,7 @@ function checkArpScan() {
 program
     .version(pck.version)
     .option('-C, --check-arpscan', 'Test to see if arp-scan is installed', checkArpScan)
-    .option('-i, --interface [interface]', 'Interface to scan linux wlan0 macos en0', netInterface)
+    .option('-i, --interface [interface]', 'Interface to scan. Use "none" to ommit interface', netInterface)
     .option('-v, --verbose', 'Verbose mode', false)
     .parse(process.argv);
 

--- a/lib/arpscanner.js
+++ b/lib/arpscanner.js
@@ -61,10 +61,9 @@ function scanner(cb, options) {
 
     const parser = isMac() ? parseMac(out) : parse(out);
 
-    if (isMac()) {
-        options.args = options.args.concat(['-i', options.interface]);
-    } else {
-        options.args = options.args.concat(['-interface', options.interface]);
+    if (options.interface !== 'none') {
+        let int = isMac() ? '-i' : '-interface';
+        options.args = options.args.concat([int, options.interface]);
     }
 
     if (options.verbose) {


### PR DESCRIPTION
This closes #12 by making interface optional. You must call the command with the flag `-i` set to **none**:
```
arpscan -i none 
```